### PR TITLE
Fix 'Bad state: Cannot set the body fields of a Request with content-type "application/json"' error

### DIFF
--- a/lib/trakt_manager_requests/authentication_requests.dart
+++ b/lib/trakt_manager_requests/authentication_requests.dart
@@ -56,7 +56,7 @@ class Authentication extends Category {
       "client_id": _manager._clientId!,
       "client_secret": _manager._clientSecret!,
     };
-    final response = await _manager.client.post(url, headers: {"Content-Type": "application/json"}, body: body);
+    final response = await _manager.client.post(url, headers: {"Content-Type": "application/json"}, body: jsonEncode(body));
 
     if (![200, 201, 204].contains(response.statusCode)) {
       throw TraktManagerAPIError(response.statusCode, response.reasonPhrase, response);

--- a/lib/trakt_manager_requests/authentication_requests.dart
+++ b/lib/trakt_manager_requests/authentication_requests.dart
@@ -76,7 +76,7 @@ class Authentication extends Category {
       "redirect_uri": _manager._redirectURI!,
       "grant_type": "authorization_code"
     });
-    final response = await _manager.client.post(url, headers: {"Content-Type": "application/json"}, body: body);
+    final response = await _manager.client.post(url, headers: {"Content-Type": "application/json"}, body: jsonEncode(body));
 
     if (![200, 201, 204].contains(response.statusCode)) {
       throw TraktManagerAPIError(response.statusCode, response.reasonPhrase, response);


### PR DESCRIPTION
This MR fixes the 'Bad state: Cannot set the body fields of a Request with content-type "application/json"' error that was occurring in the `_oauthToken` function of the `trakt_dart` package. The issue was that a `Map<String, String>` was being passed as the body of the HTTP request, but the `Content-Type` header was set to `application/json`.

To solve this, the `Map<String, String>` is converted to a JSON string using the `jsonEncode` function before sending it as the request body.